### PR TITLE
Makefile

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -2,9 +2,9 @@ name: Test Incoming Changes
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -45,4 +45,4 @@ jobs:
       run: go get github.com/golang/mock/mockgen && make mocks
 
     - name: Run Tests
-      run: make unit-tests
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@
 	run-container-tests \
 	run-operator-tests
 
-# Export GO111MODULE=on to enable project to be built from within GOPATH/src
-export GO111MODULE=on
-
 ifeq (,$(shell go env GOBIN))
   GOBIN=$(shell go env GOPATH)/bin
 else

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ else
   GOBIN=$(shell go env GOBIN)
 endif
 
-export COMMON_GO_ARGS=-race
+COMMON_GO_ARGS=-race
 
 build:
 	make mocks

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ certification.  Please see "CNF Developers" below for more information.
 
 ## Dependencies
 
-At a minimum, the following dependencies must be installed *prior* to running `make dependencies`.
+At a minimum, the following dependencies must be installed *prior* to running `make deps-install`.
 
 Dependency|Minimum Version
 ---|---
@@ -22,8 +22,10 @@ Dependency|Minimum Version
 All other dependencies required to run tests can be installed using the following command:
 
 ```shell-script
-make dependencies
+make deps-install
 ```
+
+*Note*: You must also make sure that `$GOBIN` (default `$GOPATH/bin`) is on your `$PATH`.
 
 *Note*:  Efforts to containerize this offering are considered a work in progress.
 
@@ -81,9 +83,7 @@ In order to build the test executable, first make sure you have satisfied the [d
 make build-cnf-tests
 ```
 
-If a build fails after `go get github.com/onsi/ginkgo/ginkgo`, add ginkgo location to the PATH: `export PATH=$PATH:~/go/bin`
-
-*Gotcha:* The `make build` command runs the unit tests for the framework, it does NOT test the CNF.
+*Gotcha:* The `make build*` commands run unit tests where appropriate. They do NOT test the CNF.
 
 ### Testing a CNF
 

--- a/test-network-function/container/suite.go
+++ b/test-network-function/container/suite.go
@@ -96,7 +96,7 @@ var _ = ginkgo.Describe(testSpecName, func() {
 					test, err := tnf.NewTest(context.GetExpecter(), cnfInTest, []reel.Handler{cnfInTest}, context.GetErrorChannel())
 					gomega.Expect(err).To(gomega.BeNil())
 					gomega.Expect(test).ToNot(gomega.BeNil())
-					_, err = test.Run() //nolint:ineffassign  //ignore the result, as it is not required here.
+					_, err = test.Run()
 					gomega.Expect(err).To(gomega.BeNil())
 					if factsTest.Name == string(testcases.ContainerCount) {
 						containerFact.ContainerCount, _ = strconv.Atoi(cnfInTest.Facts())


### PR DESCRIPTION
A series of changes and a restructure to the Makefile with a view to consistency and making targets as self-explanatory as possible. Might confuse muscle memory though, so happy to revert parts if it's controversial.

Note: also corrected a potentially confusing omission to the README, about adding $GOBIN to $PATH, without which mockgen wasn't found.