### PR TITLE
Improve branching vernacular

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ A more extensive example is provided in [pkg/config/example.yaml](pkg/config/exa
 The test suite generates a "claim" file, which describes the system(s) under test, the tests that were run, and the
 outcome of all of the tests.  This claim file is the proof of the test run that is evaluated by Red Hat when
 "certified" status is being considered.  For more information about the contents of the claim file please see the
-[schema](https://github.com/redhat-nfvpe/test-network-function-claim/blob/master/schemas/claim.schema.json).  You can
+[schema](https://github.com/redhat-nfvpe/test-network-function-claim/blob/main/schemas/claim.schema.json).  You can
 read more about the purpose of the claim file and CNF Certification in the
 [Guide](https://redhat-connect.gitbook.io/openshift-badges/badges/cloud-native-network-functions-cnf).
 

--- a/schemas/generic-test.schema.json
+++ b/schemas/generic-test.schema.json
@@ -5,7 +5,7 @@
   "definitions": {
     "identifier": {
       "$id": "#identifier",
-      "description": "identifier is a per tnf.Test unique identifier.  For more information, consult https://github.com/redhat-nfvpe/test-network-function/blob/master/DEVELOPING.md#test-identifiers.",
+      "description": "identifier is a per tnf.Test unique identifier.  For more information, consult https://github.com/redhat-nfvpe/test-network-function/blob/main/DEVELOPING.md#test-identifiers.",
       "properties": {
         "url": {
           "type": "string",
@@ -244,7 +244,7 @@
   "properties": {
     "identifier": {
       "$ref": "#identifier",
-      "description": "identifier is a per tnf.Test unique identifier.  For more information, consult https://github.com/redhat-nfvpe/test-network-function/blob/master/DEVELOPING.md#test-identifiers."
+      "description": "identifier is a per tnf.Test unique identifier.  For more information, consult https://github.com/redhat-nfvpe/test-network-function/blob/main/DEVELOPING.md#test-identifiers."
     },
     "arguments": {
       "description": "arguments is the Unix command array.",


### PR DESCRIPTION
Fixes some remanents left over from renaming the default branch to "main".

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>