### PR TITLE
Let ping.go tnf.Test end naturally

### DIFF
--- a/pkg/tnf/handlers/ping/ping.go
+++ b/pkg/tnf/handlers/ping/ping.go
@@ -109,7 +109,7 @@ func (p *Ping) ReelMatch(_, _, match string) *reel.Step {
 
 // ReelTimeout returns a step which kills the ping test by sending it ^C.
 func (p *Ping) ReelTimeout() *reel.Step {
-	return &reel.Step{Execute: reel.CtrlC}
+	return nil
 }
 
 // ReelEOF does nothing;  ping requires no intervention on eof.

--- a/pkg/tnf/handlers/ping/ping_test.go
+++ b/pkg/tnf/handlers/ping/ping_test.go
@@ -172,10 +172,7 @@ func TestPing_ReelMatch(t *testing.T) {
 func TestPing_ReelTimeout(t *testing.T) {
 	request := ping.NewPing(testTimeoutDuration, "192.168.1.2", 1)
 	step := request.ReelTimeout()
-	assert.NotNil(t, step)
-	assert.NotNil(t, step.Execute)
-	var expect []string
-	assert.Equal(t, expect, step.Expect)
+	assert.Nil(t, step)
 }
 
 func TestPing_Timeout(t *testing.T) {


### PR DESCRIPTION
ping.go utilizes the binary executable `ping` with a `-c` count.
This means that the ping is non-continuous, and will eventually end
if the destination is unreachable.  Thus, entering an additional CTRL_C
will cause the expecter to exit the oc session.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>