### PR TITLE
Allow non-Server release versions of RHEL

### DIFF
--- a/pkg/tnf/handlers/base/redhat/version.go
+++ b/pkg/tnf/handlers/base/redhat/version.go
@@ -31,7 +31,7 @@ const (
 	// NotRedHatBasedRegex is the expected output for a container that is not based on Red Hat technologies.
 	NotRedHatBasedRegex = `(?m)Unknown Base Image`
 	// VersionRegex is regular expression expected for a container based on Red Hat technologies.
-	VersionRegex = `(?m)Red Hat Enterprise Linux Server release (\d+\.\d+) \(\w+\)`
+	VersionRegex = `(?m)Red Hat Enterprise Linux( Server)? release (\d+\.\d+) \(\w+\)`
 )
 
 var (

--- a/pkg/tnf/handlers/base/redhat/version_test.go
+++ b/pkg/tnf/handlers/base/redhat/version_test.go
@@ -17,6 +17,7 @@
 package redhat_test
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -79,8 +80,17 @@ func TestRelease_ReelTimeout(t *testing.T) {
 	assert.Nil(t, step)
 }
 
-func TestRelease_ReelEof(t *testing.T) {
+func TestRelease_ReelEOF(t *testing.T) {
 	// just ensures no panics
 	r := redhat.NewRelease(testTimeoutDuration)
 	r.ReelEOF()
+}
+
+func TestRelease_VersionRegex(t *testing.T) {
+	r := regexp.MustCompile(redhat.VersionRegex)
+	// As we encounter more (and more) variations of /etc/redhat-release contents, do a quick compile time check to make
+	// sure the VersionRegex should still match.
+	assert.True(t, r.MatchString("Red Hat Enterprise Linux Server release 7.8 (Maipo)"))
+	assert.True(t, r.MatchString("Red Hat Enterprise Linux release 8.2 (Ootpa)"))
+	assert.False(t, r.MatchString("Won't match."))
 }


### PR DESCRIPTION
Allow for non-Server container base images.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>