### PR TITLE
Add the ability to exclude certain CNF containers from connectivity t…

### DIFF
--- a/pkg/config/generic.go
+++ b/pkg/config/generic.go
@@ -174,4 +174,6 @@ type TestConfiguration struct {
 	ContainersUnderTest map[ContainerIdentifier]Container `yaml:"containersUnderTest" json:"containersUnderTest"`
 	PartnerContainers   map[ContainerIdentifier]Container `yaml:"partnerContainers" json:"partnerContainers"`
 	TestOrchestrator    ContainerIdentifier               `yaml:"testOrchestrator" json:"testOrchestrator"`
+	// ExcludeContainersFromConnectivityTests excludes specific containers from network connectivity tests.  This is particularly useful for containers that don't have ping available.
+	ExcludeContainersFromConnectivityTests []ContainerIdentifier `yaml:"excludeContainersFromConnectivityTests" json:"excludeContainersFromConnectivityTests"`
 }


### PR DESCRIPTION
…ests

Adds the ability to add certain CNF containers to an exclusion list
for connectivity tests.  This is useful as not all containers have
`ping` or `ip addr` commands available.  This is evidenced in testing
with actual vendors in the lab.

Signed-off-by: Ryan Goulding <rgouldin@redhat.com>