### PR TITLE
add a mapping for test result code to Unix return code

### DIFF
--- a/cmd/oc/main.go
+++ b/cmd/oc/main.go
@@ -29,16 +29,24 @@ import (
 	expect "github.com/ryandgoulding/goexpect"
 )
 
+const (
+	// incorrectUsageExitCode is the Unix return code used when the supplied arguments are inappropriate.
+	incorrectUsageExitCode = 2
+
+	// mandatoryNumArgs is the number of positional arguments required.
+	mandatoryNumArgs = 3
+)
+
 func parseArgs() (*interactive.Oc, <-chan error, string, time.Duration, error) { //nolint:gocritic //permit unnamed return values
 	timeout := flag.Int("t", 2, "Timeout in seconds")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: %s [-t timeout] pod container targetIpAddress ?oc-exec-opt ... oc-exec-opt?\n", os.Args[0])
 		flag.PrintDefaults()
-		os.Exit(tnf.ERROR)
+		os.Exit(incorrectUsageExitCode)
 	}
 	flag.Parse()
 	args := flag.Args()
-	if len(args) < 3 { //nolint:gomnd
+	if len(args) < mandatoryNumArgs {
 		flag.Usage()
 	}
 
@@ -60,7 +68,7 @@ func main() {
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(result)
+		os.Exit(tnf.ExitCodeMap[result])
 	}
 
 	request := ping.NewPing(timeoutDuration, targetIPAddress, 5)
@@ -73,5 +81,5 @@ func main() {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
-	os.Exit(result)
+	os.Exit(tnf.ExitCodeMap[result])
 }

--- a/cmd/ping/main.go
+++ b/cmd/ping/main.go
@@ -29,17 +29,25 @@ import (
 	expect "github.com/ryandgoulding/goexpect"
 )
 
+const (
+	// incorrectUsageExitCode is the Unix return code used when the supplied arguments are inappropriate.
+	incorrectUsageExitCode = 2
+
+	// mandatoryNumArgs is the number of positional arguments required.
+	mandatoryNumArgs = 1
+)
+
 func parseArgs() (*ping.Ping, time.Duration) {
 	timeout := flag.Int("t", 2, "Timeout in seconds")
 	count := flag.Int("c", 1, "Number of requests to send")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: %s [-t timeout] [-c count] host\n", os.Args[0])
 		flag.PrintDefaults()
-		os.Exit(tnf.ERROR)
+		os.Exit(incorrectUsageExitCode)
 	}
 	flag.Parse()
 	args := flag.Args()
-	if len(args) == 0 {
+	if len(args) < mandatoryNumArgs {
 		flag.Usage()
 	}
 	timeoutDuration := time.Duration(*timeout) * time.Second
@@ -58,7 +66,7 @@ func main() {
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(result)
+		os.Exit(tnf.ExitCodeMap[result])
 	}
 	tester, err := tnf.NewTest(context.GetExpecter(), pingReel, []reel.Handler{pingReel}, context.GetErrorChannel())
 
@@ -68,5 +76,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 	}
 
-	os.Exit(result)
+	os.Exit(tnf.ExitCodeMap[result])
 }

--- a/cmd/ssh/main.go
+++ b/cmd/ssh/main.go
@@ -29,16 +29,24 @@ import (
 	expect "github.com/ryandgoulding/goexpect"
 )
 
+const (
+	// incorrectUsageExitCode is the Unix return code used when the supplied arguments are inappropriate.
+	incorrectUsageExitCode = 2
+
+	// mandatoryNumArgs is the number of positional arguments required.
+	mandatoryNumArgs = 3
+)
+
 func parseArgs() (*interactive.Context, string, time.Duration, error) {
 	timeout := flag.Int("t", 2, "Timeout in seconds")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: %s [-t timeout] user host targetIpAddress\n", os.Args[0])
 		flag.PrintDefaults()
-		os.Exit(tnf.ERROR)
+		os.Exit(incorrectUsageExitCode)
 	}
 	flag.Parse()
 	args := flag.Args()
-	if len(args) < 3 { //nolint:gomnd
+	if len(args) < mandatoryNumArgs {
 		flag.Usage()
 	}
 
@@ -57,7 +65,7 @@ func main() {
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(result)
+		os.Exit(tnf.ExitCodeMap[result])
 	}
 
 	request := ping.NewPing(timeoutDuration, targetIPAddress, 5)
@@ -71,5 +79,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 	}
 
-	os.Exit(result)
+	os.Exit(tnf.ExitCodeMap[result])
 }

--- a/pkg/tnf/test.go
+++ b/pkg/tnf/test.go
@@ -33,6 +33,13 @@ const (
 	FAILURE
 )
 
+// ExitCodeMap maps a test result value to a more appropriate Unix return code.
+var ExitCodeMap = map[int]int{
+	SUCCESS: 0,
+	FAILURE: 1,
+	ERROR:   2,
+}
+
 // Tester provides the interface for a Test.
 type Tester interface {
 	// Args returns the CLI command as a string array.


### PR DESCRIPTION
A recent change to use `0` as the ERROR value for test result meant
that some components were reporting a success when they had failed.

This change adds a map to transform the value of test result to a
meaningful Unix exit code.

Signed-off-by: Charlie Wheeler-Robinson <cwheeler@redhat.com>